### PR TITLE
added powershell-v2 support and fixed array issue

### DIFF
--- a/AdAudit.ps1
+++ b/AdAudit.ps1
@@ -102,7 +102,7 @@ function Get-LAPSStatus{#Check for presence of LAPS in domain
 }
 
 Function Get-PrivilegedGroupAccounts{#lists users in Admininstrators, DA and EA groups
-    [array]$privilegedusersarray = @()
+    [array]$privilegedusers = @()
     $privilegedusers += Get-ADGroupMember "administrators" -Recursive
     $privilegedusers += Get-ADGroupMember "domain admins" -Recursive
     $privilegedusers += Get-ADGroupMember "enterprise admins" -Recursive


### PR DESCRIPTION
This PR edits the script to work with powershell-v2 for use with older server versions. The 'Get-Content' cmdlet in powershell-v2 doesn't have the 'Raw' switch. This has been replaced with [System.IO.File]::ReadAllText for the same outcome. 

There is also a fix to the Get-PrivilegedGroupAccounts function. An error can occur where the administrators group contains a single account. This would mean an object, rather than an array of objects is assigned to the privilegedusers variable. Objects and arrays of objects can not then be added to that variable. The fix was to create a blank array, and add objects or arrays of objects to that. 