### PR TITLE
Update AdAudit.ps1

### DIFF
--- a/AdAudit.ps1
+++ b/AdAudit.ps1
@@ -60,29 +60,29 @@ param (
 $versionnum = "v5.0"
 
 Function Get-Variables(){#retrieve group names and os version
-    $Administrators                 = (Get-ADGroup -Identity S-1-5-32-544).SamAccountName
-    $Users                          = (Get-ADGroup -Identity S-1-5-32-545).SamAccountName
-    $DomainAdminsSID                = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-512"
-    $DomainUsersSID                 = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-513"
-    $DomainControllersSID           = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-516"
-    $SchemaAdminsSID                = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-518"
-    $EnterpriseAdminsSID            = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-519"
-    $ProtectedUsersSID              = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-525"
-    $EveryOneSID                    = New-Object System.Security.Principal.SecurityIdentifier "S-1-1-0"
-    $EntrepriseDomainControllersSID = New-Object System.Security.Principal.SecurityIdentifier "S-1-5-9"
-    $AuthenticatedUsersSID          = New-Object System.Security.Principal.SecurityIdentifier "S-1-5-11"
-    $LocalServiceSID                = New-Object System.Security.Principal.SecurityIdentifier "S-1-5-19"
-    $DomainAdmins                   = (Get-ADGroup -Identity $DomainAdminsSID).SamAccountName
-    $DomainUsers                    = (Get-ADGroup -Identity $DomainUsersSID).SamAccountName
-    $DomainControllers              = (Get-ADGroup -Identity $DomainControllersSID).SamAccountName
-    $SchemaAdmins                   = (Get-ADGroup -Identity $SchemaAdminsSID).SamAccountName
-    $EnterpriseAdmins               = (Get-ADGroup -Identity $EnterpriseAdminsSID).SamAccountName
-    $ProtectedUsers                 = (Get-ADGroup -Identity $ProtectedUsersSID).SamAccountName
-    $EveryOne                       = $EveryOneSID.Translate([System.Security.Principal.NTAccount]).Value
-    $EntrepriseDomainControllers    = $EntrepriseDomainControllersSID.Translate([System.Security.Principal.NTAccount]).Value
-    $AuthenticatedUsers             = $AuthenticatedUsersSID.Translate([System.Security.Principal.NTAccount]).Value
-    $LocalService                   = $LocalServiceSID.Translate([System.Security.Principal.NTAccount]).Value
-    $OSVersion                      = (Get-Itemproperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name ProductName).ProductName
+    $script:Administrators                 = (Get-ADGroup -Identity S-1-5-32-544).SamAccountName
+    $script:Users                          = (Get-ADGroup -Identity S-1-5-32-545).SamAccountName
+    $script:DomainAdminsSID                = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-512"
+    $script:DomainUsersSID                 = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-513"
+    $script:DomainControllersSID           = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-516"
+    $script:SchemaAdminsSID                = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-518"
+    $script:EnterpriseAdminsSID            = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-519"
+    $script:ProtectedUsersSID              = ((Get-ADDomain -Current LoggedOnUser).domainsid.value)+"-525"
+    $script:EveryOneSID                    = New-Object System.Security.Principal.SecurityIdentifier "S-1-1-0"
+    $script:EntrepriseDomainControllersSID = New-Object System.Security.Principal.SecurityIdentifier "S-1-5-9"
+    $script:AuthenticatedUsersSID          = New-Object System.Security.Principal.SecurityIdentifier "S-1-5-11"
+    $script:LocalServiceSID                = New-Object System.Security.Principal.SecurityIdentifier "S-1-5-19"
+    $script:DomainAdmins                   = (Get-ADGroup -Identity $DomainAdminsSID).SamAccountName
+    $script:DomainUsers                    = (Get-ADGroup -Identity $DomainUsersSID).SamAccountName
+    $script:DomainControllers              = (Get-ADGroup -Identity $DomainControllersSID).SamAccountName
+    $script:SchemaAdmins                   = (Get-ADGroup -Identity $SchemaAdminsSID).SamAccountName
+    $script:EnterpriseAdmins               = (Get-ADGroup -Identity $EnterpriseAdminsSID).SamAccountName
+    $script:ProtectedUsers                 = (Get-ADGroup -Identity $ProtectedUsersSID).SamAccountName
+    $script:EveryOne                       = $EveryOneSID.Translate([System.Security.Principal.NTAccount]).Value
+    $script:EntrepriseDomainControllers    = $EntrepriseDomainControllersSID.Translate([System.Security.Principal.NTAccount]).Value
+    $script:AuthenticatedUsers             = $AuthenticatedUsersSID.Translate([System.Security.Principal.NTAccount]).Value
+    $script:LocalService                   = $LocalServiceSID.Translate([System.Security.Principal.NTAccount]).Value
+    $script:OSVersion                      = (Get-Itemproperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name ProductName).ProductName
     Write-Both "    [+] Administrators:  $Administrators"
     Write-Both "    [+] Users:  $Users"
     Write-Both "    [+] Domain Admins:  $DomainAdmins"

--- a/AdAudit.ps1
+++ b/AdAudit.ps1
@@ -55,7 +55,7 @@ param (
   [switch]$laps = $false,
   [switch]$authpolsilos = $false,
   [switch]$insecurednszone = $false,
-  [switch]$all = $true
+  [switch]$all = $false
 )
 $versionnum = "v5.0"
 
@@ -116,7 +116,7 @@ Function Write-Nessus-Footer(){
     Add-Content -Path "$outputdir\adaudit.nessus" -Value "</ReportHost></Report></AdAudit>"
 }
 Function Get-DNSZoneInsecure{#Check DNS zones allowing insecure updates
-    if ($OSVersion -like "Windows Server 2008*") {
+    if ($OSVersion -notlike "Windows Server 2008*") {
         $count = 0
         $progresscount = 0
         $insecurezones = Get-DnsServerZone | Where-Object {$_.DynamicUpdate -like '*nonsecure*'}
@@ -949,6 +949,7 @@ if (!$running) { Write-Both "[!] No arguments selected;"
     Write-Both "    -ouperms checks generic OU permission issues"
     Write-Both "    -laps checks if LAPS is installed"
     Write-Both "    -authpolsilos checks for existenece of authentication policies and silos"
+    Write-Both "    -insecurednszone checks for insecure dns zones"
     Write-Both "    -all runs all checks, e.g. $scriptname -all"
 }
 Write-Nessus-Footer

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Run directly on a DC using a DA. If you don't trust the code I suggest reading i
   * Get-LAPSStatus
 * Check For Existence of Authentication Polices and Silos
   * Get-AuthenticationPoliciesAndSilos
+* Check for insecure DNS zones
+  * Get-DNSZoneInsecure
 
 ## Runtime Args
 The following switches can be used in combination
@@ -61,4 +63,5 @@ The following switches can be used in combination
 * -ouperms checks generic OU permission issues
 * -laps checks if LAPS is installed
 * -authpolsilos checks for existenece of authentication policies and silos
+* -insecurednszone checks for insecure dns zones
 * -all runs all checks, e.g. AdAudit.ps1 -all


### PR DESCRIPTION
Added support for other languages
Added missing WS 2019
Fixed cpassword search (false positive if you find cpassword="")
Fixed Get-ACL bad syntax
Fixed Get-DNSZoneInsecure for WS 2008
Updated help section for DNS zone check

Tested OK on WS 2008R2, 2012R2, 2016 and 2019